### PR TITLE
Fixed "pop" method breaking the program

### DIFF
--- a/stackMachine.py
+++ b/stackMachine.py
@@ -67,6 +67,7 @@ def runAsm(asm, stack=[]):
                         data[var],stack = stackOperations.pop(stack)
                     else:
                         variable,stack = stackOperations.pop(stack)
+                        pc+=1
 
                 else:
                     if len(instruction) > 1 and instruction[1] in data:


### PR DESCRIPTION
At the end of the if block which executed the "pop" method there was an PC increment missing. Due to this, stack machine would crash every time pop was called; It would start popping all elements until none were left and then give Python IndexError "pop from empty stack".